### PR TITLE
Integrate OpenAI moderation endpoint (conflict-clean)

### DIFF
--- a/src/worker/comments.ts
+++ b/src/worker/comments.ts
@@ -422,14 +422,6 @@ export function createCommentsApp() {
       return c.json({ error: `comment exceeds ${MAX_BODY_LEN} chars` }, 400);
     }
 
-    // Pre-save moderation
-    if (c.env.OPENAI_API_KEY) {
-      const flagged = await openaiModerate(body, c.env.OPENAI_API_KEY);
-      if (flagged) {
-        return c.json({ error: "comment was flagged by moderation" }, 400);
-      }
-    }
-
     if (parent_id) {
       const parent = await c.env.DB
         .prepare("SELECT id, slug FROM comments WHERE id = ?")
@@ -450,6 +442,14 @@ export function createCommentsApp() {
         });
       }
       throw e;
+    }
+
+    // Pre-save moderation
+    if (c.env.OPENAI_API_KEY) {
+      const flagged = await openaiModerate(body, c.env.OPENAI_API_KEY);
+      if (flagged) {
+        return c.json({ error: "comment was flagged by moderation" }, 400);
+      }
     }
 
     const id = crypto.randomUUID();

--- a/src/worker/comments.ts
+++ b/src/worker/comments.ts
@@ -7,7 +7,7 @@ import {
 } from "./identity";
 import { slugify } from "./slug";
 import { rateLimit, clientIp } from "./ratelimit";
-import { moderateCommentNow } from "./moderation";
+import { moderateCommentNow, openaiModerate } from "./moderation";
 
 export interface CommentsEnv {
   DB: D1Database;
@@ -16,6 +16,7 @@ export interface CommentsEnv {
   OPENROUTER_MODEL: string;
   OPENROUTER_MODERATION_MODEL?: string;
   IDENT_PER_IP_PER_HOUR?: string;
+  OPENAI_API_KEY?: string;
 }
 
 const COOKIE_NAME = "hu_uid";
@@ -419,6 +420,14 @@ export function createCommentsApp() {
     if (!body) return c.json({ error: "comment is empty" }, 400);
     if (body.length > MAX_BODY_LEN) {
       return c.json({ error: `comment exceeds ${MAX_BODY_LEN} chars` }, 400);
+    }
+
+    // Pre-save moderation
+    if (c.env.OPENAI_API_KEY) {
+      const flagged = await openaiModerate(body, c.env.OPENAI_API_KEY);
+      if (flagged) {
+        return c.json({ error: "comment was flagged by moderation" }, 400);
+      }
     }
 
     if (parent_id) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -14,9 +14,11 @@ import { isLikelyVpn } from "./vpn";
 import { isPermanentlyBlockedSlug } from "./blocklist";
 import { loadHints, saveHints } from "./hints";
 import {
+  banSlugNow,
   countRecentBansByIp,
   enqueueArticleForModeration,
   isSlugBanned,
+  openaiModerate,
   runSweep,
 } from "./moderation";
 
@@ -40,6 +42,9 @@ export interface Env {
   SEARCH_PER_IP_PER_HOUR?: string;
   // Single Durable Object tracking live readers per slug. See presence.ts.
   PRESENCE: DurableObjectNamespace;
+  // Optional: OpenAI API key for synchronous pre-generation moderation.
+  // Set via: pnpm wrangler secret put OPENAI_API_KEY
+  OPENAI_API_KEY?: string;
 }
 
 interface StoredArticle {
@@ -553,6 +558,23 @@ app.get("/api/page/:slug", async (c) => {
   }
 
   const title = slugToTitle(slug);
+
+  // Check title against OpenAI Moderation API before spending LLM tokens
+  if (c.env.OPENAI_API_KEY) {
+    const flagged = await openaiModerate(title, c.env.OPENAI_API_KEY);
+    if (flagged) {
+      c.executionCtx.waitUntil(
+        banSlugNow(slug, c.env).catch((e) =>
+          console.error("banSlugNow failed", e)
+        )
+      );
+      return c.json(
+        { error: "this entry has been removed by moderation", banned: true },
+        404,
+        { "x-robots-tag": "noindex" }
+      );
+    }
+  }
 
   // Pull every prior link-context blurb other articles have written about
   // this slug. These become CANON the LLM must respect.

--- a/src/worker/moderation.ts
+++ b/src/worker/moderation.ts
@@ -32,9 +32,15 @@ export async function openaiModerate(
   text: string,
   apiKey: string
 ): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, 5000);
+
   try {
     const res = await fetch("https://api.openai.com/v1/moderations", {
       method: "POST",
+      signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
@@ -46,6 +52,8 @@ export async function openaiModerate(
     return json?.results?.[0]?.flagged === true;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/src/worker/moderation.ts
+++ b/src/worker/moderation.ts
@@ -21,6 +21,58 @@ export interface ModerationEnv {
   OPENROUTER_API_KEY: string;
   OPENROUTER_MODEL: string;
   OPENROUTER_MODERATION_MODEL?: string;
+  OPENAI_API_KEY?: string;
+}
+
+/**
+ * Call the OpenAI Moderation API and return true if the text was flagged.
+ * If this fails, the async sweep can still catch stragglers.
+ */
+export async function openaiModerate(
+  text: string,
+  apiKey: string
+): Promise<boolean> {
+  try {
+    const res = await fetch("https://api.openai.com/v1/moderations", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model: "omni-moderation-latest", input: text }),
+    });
+    if (!res.ok) return false;
+    const json: any = await res.json();
+    return json?.results?.[0]?.flagged === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Immediately mark slug as banned in DB and delete it from KV.
+ * Used when the pre-check flags a slug before generation starts.
+ */
+export async function banSlugNow(
+  slug: string,
+  env: ModerationEnv
+): Promise<void> {
+  const now = Date.now();
+  try {
+    await env.ARTICLES.delete(slug);
+  } catch {}
+  try {
+    await env.DB
+      .prepare(
+        `INSERT INTO article_moderation (slug, status, reason, enqueued_at, checked_at)
+         VALUES (?, 'banned', ?, ?, ?)
+         ON CONFLICT(slug) DO UPDATE SET status='banned', reason=excluded.reason, checked_at=excluded.checked_at`
+      )
+      .bind(slug, "openai-moderation-precheck", now, now)
+      .run();
+  } catch (e) {
+    console.error("banSlugNow: DB write failed", slug, e);
+  }
 }
 
 const BATCH_SIZE = 30;

--- a/src/worker/moderation.ts
+++ b/src/worker/moderation.ts
@@ -35,7 +35,7 @@ export async function openaiModerate(
   const controller = new AbortController();
   const timeout = setTimeout(() => {
     controller.abort();
-  }, 5000);
+  }, 4000);
 
   try {
     const res = await fetch("https://api.openai.com/v1/moderations", {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -56,3 +56,8 @@ class_name = "PresenceDO"
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["PresenceDO"]
+# Enable OpenAI Moderation API for slugs and comments
+# pnpm wrangler secret put OPENAI_API_KEY
+
+# Enable OpenAI Moderation API for slugs and comments
+# pnpm wrangler secret put OPENAI_API_KEY


### PR DESCRIPTION
This is a conflict-clean replacement for the moderation work originally proposed in PR #4.

Why this PR exists:
- The original PR became merge-conflicting after upstream introduced Presence DO env/binding changes.
- This branch preserves the intended behavior:
  - Pre-check article titles with OpenAI Moderation before generation.
  - Immediately mark flagged slugs as banned and remove them from KV.
  - Keep existing Presence DO bindings in `wrangler.toml` while adding OpenAI moderation configuration.
  - Reuse the same asynchronous moderation flow for comments in `moderation.ts`.

Please review this as the replacement for PR #4.

Related prior PR: https://github.com/BaderBC/halupedia/pull/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional AI moderation for comments and generated pages: flagged comments are rejected before publishing and flagged pages are blocked from being served (returned as not found with noindex).
  * Flagged slugs are immediately removed/marked to prevent further processing and indexing.

* **Chores**
  * Configuration guidance updated to support enabling the AI moderation integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BaderBC/halupedia/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->